### PR TITLE
fix: cache option in TerserPlugin config not valid

### DIFF
--- a/static/serverlessWebpackConfig.template.js
+++ b/static/serverlessWebpackConfig.template.js
@@ -117,7 +117,6 @@ module.exports = {
     minimizer: [
       new TerserPlugin({
         parallel: true,
-        cache: true,
         // sourceMap: true,
         terserOptions: {
           keep_classnames: true,


### PR DESCRIPTION
According to the documentation https://webpack.js.org/plugins/terser-webpack-plugin/ the cache parameter does not seem to be a valid parameter. When running cantara there is also reported this error message:
Serverless: Could not load webpack config '***/api_serverlessWebpackConfig.js'
ValidationError: Invalid options object. Terser Plugin has been initialized using an options object that does not match the API schema.
   - options has an unknown property 'cache'.
...